### PR TITLE
Change regex string to raw string to avoid regex deprecation warnings

### DIFF
--- a/acme-dns-server.py
+++ b/acme-dns-server.py
@@ -9,7 +9,7 @@ import sys
 
 HEADER = '!HBBHHHH'
 HEADER_SIZE = struct.calcsize(HEADER)
-DOMAIN_PATTERN = re.compile('^[A-Za-z0-9\-\.\_]+$')
+DOMAIN_PATTERN = re.compile(r'^[A-Za-z0-9-._]+$')
 
 # Data path, will be updated from argparse
 data_path = ''


### PR DESCRIPTION
Tested and working using Python 3.14.5.

Solves https://github.com/pawitp/acme-dns-server/issues/3